### PR TITLE
Parser.withSource() parser

### DIFF
--- a/src/main/java/org/codehaus/jparsec/Parser.java
+++ b/src/main/java/org/codehaus/jparsec/Parser.java
@@ -488,6 +488,13 @@ public abstract class Parser<T> {
   }
 
   /**
+   * A {@link Parser} that returns both parsed object and matched string.
+   */
+  public final Parser<WithSource<T>> withSource() {
+    return new WithSourceParser<T>(this);
+  }
+
+  /**
    * A {@link Parser} that takes as input the {@link Token} collection returned by {@code lexer}, and runs {@code
    * this} to parse the tokens.
    * <p/>

--- a/src/main/java/org/codehaus/jparsec/ReturnSourceParser.java
+++ b/src/main/java/org/codehaus/jparsec/ReturnSourceParser.java
@@ -19,6 +19,8 @@ package org.codehaus.jparsec;
  * Returns the source string of the part that matches the target parser.
  * 
  * @author Ben Yu
+ *
+ * @see org.codehaus.jparsec.WithSourceParser
  */
 final class ReturnSourceParser extends Parser<String> {
   private final Parser<?> parser;

--- a/src/main/java/org/codehaus/jparsec/ToTokenParser.java
+++ b/src/main/java/org/codehaus/jparsec/ToTokenParser.java
@@ -4,6 +4,8 @@ package org.codehaus.jparsec;
  * Converts the current return value as a {@link Token} with starting index and length.
  * 
  * @author Ben Yu
+ *
+ * @see org.codehaus.jparsec.WithSourceParser
  */
 final class ToTokenParser extends Parser<Token> {
   private final Parser<?> parser;

--- a/src/main/java/org/codehaus/jparsec/WithSource.java
+++ b/src/main/java/org/codehaus/jparsec/WithSource.java
@@ -1,0 +1,45 @@
+package org.codehaus.jparsec;
+
+/**
+ * @author Stepan Koltsov
+ */
+public class WithSource<T> {
+  private final T value;
+  private final String source;
+
+  public WithSource(T value, String source) {
+    this.value = value;
+    this.source = source;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  /** Returns the string representation of the token value. */
+  @Override public String toString() {
+    return String.valueOf(value);
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    WithSource that = (WithSource) o;
+
+    if (value != null ? !value.equals(that.value) : that.value != null) return false;
+    if (source != null ? !source.equals(that.source) : that.source != null) return false;
+
+    return true;
+  }
+
+  @Override public int hashCode() {
+    int result = value != null ? value.hashCode() : 0;
+    result = 31 * result + (source != null ? source.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/org/codehaus/jparsec/WithSourceParser.java
+++ b/src/main/java/org/codehaus/jparsec/WithSourceParser.java
@@ -1,0 +1,33 @@
+package org.codehaus.jparsec;
+
+/**
+ * Converts the current return value as a {@link org.codehaus.jparsec.WithSource}
+ * with string that matches it.
+ *
+ * @author Stepan Koltsov
+ *
+ * @see org.codehaus.jparsec.ReturnSourceParser
+ * @see org.codehaus.jparsec.ToTokenParser
+ */
+final class WithSourceParser<T> extends Parser<WithSource<T>> {
+  private final Parser<?> parser;
+
+  WithSourceParser(Parser<?> parser) {
+    this.parser = parser;
+  }
+
+  @Override boolean apply(ParseContext ctxt) {
+    int begin = ctxt.getIndex();
+    if (!parser.apply(ctxt)) {
+      return false;
+    }
+    String source = ctxt.source.subSequence(begin, ctxt.getIndex()).toString();
+    WithSource<T> withSource = new WithSource<T>((T) ctxt.result, source);
+    ctxt.result = withSource;
+    return true;
+  }
+  
+  @Override public String toString() {
+    return parser.toString();
+  }
+}

--- a/src/test/java/org/codehaus/jparsec/ParserTest.java
+++ b/src/test/java/org/codehaus/jparsec/ParserTest.java
@@ -62,6 +62,13 @@ public class ParserTest extends BaseMockTest {
     assertParser(INTEGER.token(), "123", new Token(0, 3, 123));
     assertFailure(INTEGER.token(), "a", 1, 1);
   }
+
+  public void testWithSource() {
+    assertEquals("foo", FOO.withSource().toString());
+    assertParser(FOO.withSource(), "", new WithSource<String>("foo", ""));
+    assertParser(INTEGER.withSource(), "123", new WithSource<Integer>(123, "123"));
+    assertFailure(INTEGER.withSource(), "a", 1, 1);
+  }
   
   @Mock Map<Object, Parser<String>> next;
   public void testNext_withMap() {


### PR DESCRIPTION
`Parser<T>.withSource()` parser applies this parser and returns its
result along with matches string.

`.token()` parser could be used instead of `.withSource()`, however
sometimes `WithSource` is more convenient, because global string
object has to be stored somewhere to resolve token into string.

Also, `WithSource` class is type-parameterized, unlike Token.
