### PR TITLE
mention codehaus is the old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jparsec
 =======
 
-> This is code repository for jParsec 3.0 development branch. For current version see [Codehaus](http://jparsec.codehaus.org/) site
+> This is code repository for jParsec 3.0 development branch. It used to be maintained on  [Codehaus](http://jparsec.codehaus.org/) site. I took over its maintenance on github.
 
 [![Build Status](https://travis-ci.org/abailly/jparsec.png)](https://travis-ci.org/abailly/jparsec)
 


### PR DESCRIPTION
Since you forked to github and actively maintain the repo there, there is no reason to point users to codehaus for the latest version.
