### PR TITLE
Listeners on Parser.map()

### DIFF
--- a/jparsec/src/main/java/org/codehaus/jparsec/ParseContext.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/ParseContext.java
@@ -25,6 +25,7 @@ import org.codehaus.jparsec.error.ParseErrorDetails;
 import org.codehaus.jparsec.error.ParserException;
 import org.codehaus.jparsec.internal.annotations.Private;
 import org.codehaus.jparsec.internal.util.Lists;
+import org.codehaus.jparsec.parameters.Parameters;
 
 /**
  * Represents the context state during parsing.
@@ -38,6 +39,7 @@ abstract class ParseContext {
   final String module;
   final CharSequence source;
   final SourceLocator locator;
+  final Parameters params;
   
   /** The current position of the input. Points to the token array for token level. */
   int at;
@@ -96,14 +98,15 @@ abstract class ParseContext {
   // explicit suppresses error recording if true.
   private boolean errorSuppressed = false;
   private ErrorType overrideErrorType = ErrorType.NONE;
+
   
   //caller should not change input after it is passed in.
-  ParseContext(CharSequence source, int at, String module, SourceLocator locator) {
-    this(source, null, at, module, locator);
+  ParseContext(CharSequence source, int at, String module, SourceLocator locator, Parameters params) {
+    this(source, null, at, module, locator, params);
   }
   
   ParseContext(
-      CharSequence source, Object ret, int at, String module, SourceLocator locator) {
+      CharSequence source, Object ret, int at, String module, SourceLocator locator, Parameters params) {
     this.source = source;
     this.result = ret;
     this.step = 0;
@@ -111,6 +114,7 @@ abstract class ParseContext {
     this.module = module;
     this.locator = locator;
     this.currentErrorAt = at;
+    this.params = params;
   }
 
   /** Runs {@code parser} with error recording suppressed. */

--- a/jparsec/src/main/java/org/codehaus/jparsec/ParserState.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/ParserState.java
@@ -15,6 +15,8 @@
  *****************************************************************************/
 package org.codehaus.jparsec;
 
+import org.codehaus.jparsec.parameters.Parameters;
+
 /**
  * Represents {@link ParseContext} for token level parsing.
  * 
@@ -27,7 +29,7 @@ final class ParserState extends ParseContext {
       + " For example: Scanners.string(foo).from(tokenizer).parse(text) will result in this error"
       + " because scanner works on characters while it's used as a token-level parser.";
 
-  private final Token[] input;
+  final Token[] input;
   
   // in case a terminating eof token is not explicitly created, the implicit one is used.
   private final int endIndex;
@@ -46,8 +48,8 @@ final class ParserState extends ParseContext {
   }
   
   ParserState(String module, CharSequence source, Token[] input, int at,
-      SourceLocator locator, int endIndex, Object result) {
-    super(source, result, at, module, locator);
+      SourceLocator locator, int endIndex, Object result, Parameters params) {
+    super(source, result, at, module, locator, params);
     this.input = input;
     this.endIndex = endIndex;
   }

--- a/jparsec/src/main/java/org/codehaus/jparsec/Parsers.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/Parsers.java
@@ -31,6 +31,7 @@ import org.codehaus.jparsec.functors.Tuple4;
 import org.codehaus.jparsec.functors.Tuple5;
 import org.codehaus.jparsec.internal.annotations.Private;
 import org.codehaus.jparsec.internal.util.Lists;
+import org.codehaus.jparsec.parameters.Parameters;
 
 /**
  * Provides common {@link Parser} implementations.
@@ -159,13 +160,13 @@ public final class Parsers {
    * @param parser the token level parser object.
    * @return the new Parser object.
    */
-  static <T> Parser<T> nested(final Parser<Token[]> lexer, final Parser<? extends T> parser) {
+  static <T> Parser<T> nested(final Parser<Token[]> lexer, final Parser<? extends T> parser, final Parameters params) {
     return new Parser<T>() {
       @Override boolean apply(ParseContext ctxt) {
         if (!lexer.apply(ctxt)) return false;
         Token[] tokens = lexer.getReturn(ctxt);
         ParserState parserState = new ParserState(
-            ctxt.module, ctxt.source, tokens, 0, ctxt.locator, ctxt.getIndex(), tokens);
+            ctxt.module, ctxt.source, tokens, 0, ctxt.locator, ctxt.getIndex(), tokens, ctxt.params);
         ctxt.getTrace().startFresh(parserState);
         return ctxt.applyNested(parser, parserState);
       }

--- a/jparsec/src/main/java/org/codehaus/jparsec/ReluctantBetweenParser.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/ReluctantBetweenParser.java
@@ -50,7 +50,7 @@ final class ReluctantBetweenParser<T> extends Parser<T> {
 			r2 = end.apply(ctxt);
 		}
 		if (!r2) return false;
-		ParseContext betweenCtxt = new ScannerState(ctxt.module, ctxt.source, betweenAt, endAt, ctxt.locator, ctxt.result );
+		ParseContext betweenCtxt = new ScannerState(ctxt.module, ctxt.source, betweenAt, endAt, ctxt.locator, ctxt.result, ctxt.params);
 		boolean rb = between.apply(betweenCtxt);
 		
 		if ( ! rb ) return false;

--- a/jparsec/src/main/java/org/codehaus/jparsec/ScannerState.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/ScannerState.java
@@ -16,6 +16,7 @@
 package org.codehaus.jparsec;
 
 import org.codehaus.jparsec.error.ParserException;
+import org.codehaus.jparsec.parameters.Parameters;
 
 /**
  * Parser state for scanner.
@@ -25,12 +26,12 @@ import org.codehaus.jparsec.error.ParserException;
 final class ScannerState extends ParseContext {
   private final int end;
   
-  ScannerState(CharSequence source) {
-    this(null, source, 0, new SourceLocator(source));
+  ScannerState(CharSequence source, Parameters params) {
+    this(null, source, 0, new SourceLocator(source), params);
   }
   
-  ScannerState(String module, CharSequence source, int from, SourceLocator locator) {
-    super(source, from, module, locator);
+  ScannerState(String module, CharSequence source, int from, SourceLocator locator, Parameters params) {
+    super(source, from, module, locator, params);
     this.end = source.length();
   }
   
@@ -43,8 +44,8 @@ final class ScannerState extends ParseContext {
    * @param originalResult the original result value
    */
   ScannerState(String module, CharSequence source, int from, int end,
-      SourceLocator locator, Object originalResult) {
-    super(source, originalResult, from, module, locator);
+      SourceLocator locator, Object originalResult, Parameters params) {
+    super(source, originalResult, from, module, locator, params);
     this.end = end;
   }
   

--- a/jparsec/src/main/java/org/codehaus/jparsec/Scanners.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/Scanners.java
@@ -537,7 +537,7 @@ public final class Scanners {
         int from = ctxt.at;
         if (!outer.apply(ctxt)) return false;
         ScannerState innerState = new ScannerState(
-            ctxt.module, ctxt.characters(), from, ctxt.at, ctxt.locator, ctxt.result);
+            ctxt.module, ctxt.characters(), from, ctxt.at, ctxt.locator, ctxt.result, ctxt.params);
         ctxt.getTrace().startFresh(innerState);
         innerState.getTrace().setStateAs(ctxt.getTrace());
         return ctxt.applyNested(inner, innerState);

--- a/jparsec/src/main/java/org/codehaus/jparsec/parameters/MapListener.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/parameters/MapListener.java
@@ -1,0 +1,6 @@
+package org.codehaus.jparsec.parameters;
+
+
+public interface MapListener {
+	public void onMap(Object object, ParseLevelState state);
+}

--- a/jparsec/src/main/java/org/codehaus/jparsec/parameters/Parameters.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/parameters/Parameters.java
@@ -1,0 +1,28 @@
+package org.codehaus.jparsec.parameters;
+
+import org.codehaus.jparsec.Parser.Mode;
+
+/**
+ * Runtime parameters applied to a parse execution.
+ * @author Sylvain Colomer
+ */
+public class Parameters {
+	private MapListener mapListener;
+	private Mode mode = Mode.PRODUCTION;
+	
+	public Mode getMode() {
+		return mode;
+	}
+
+	public void setMode(Mode mode) {
+		this.mode = mode;
+	}
+
+	public MapListener getMapListener() {
+		return mapListener;
+	}
+
+	public void setMapListener(MapListener mapListener) {
+		this.mapListener = mapListener;
+	}
+}

--- a/jparsec/src/main/java/org/codehaus/jparsec/parameters/ParseLevelState.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/parameters/ParseLevelState.java
@@ -1,0 +1,28 @@
+package org.codehaus.jparsec.parameters;
+
+import org.codehaus.jparsec.Token;
+
+public class ParseLevelState {
+  private Token first;
+  private Token last;
+  private Parameters params;
+
+  public ParseLevelState(Token first, Token last, Parameters params) {
+    this.first = first;
+    this.last = last;
+    this.params = params;
+  }
+  
+  public Token getFirstToken() {
+    return first;
+  }
+
+  public Token getLastToken() {
+    return last;
+  }
+  
+  public Parameters getParams() {
+    return params;
+  }
+
+}

--- a/jparsec/src/test/java/org/codehaus/jparsec/parameters/Declaration.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/parameters/Declaration.java
@@ -1,0 +1,19 @@
+package org.codehaus.jparsec.parameters;
+
+public class Declaration extends Node {
+	private Identifier id;
+
+	public Declaration(Identifier id) {
+		super();
+		this.id = id;
+	}
+
+	public Identifier getId() {
+		return id;
+	}
+
+	@Override
+	public String toString() {
+		return "Declaration [id=" + id + "]";
+	}
+}

--- a/jparsec/src/test/java/org/codehaus/jparsec/parameters/Identifier.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/parameters/Identifier.java
@@ -1,0 +1,19 @@
+package org.codehaus.jparsec.parameters;
+
+public class Identifier extends Node {
+	private String name;
+
+	public Identifier(String name) {
+		super();
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return "Identifier [name=" + name + "]";
+	}
+}

--- a/jparsec/src/test/java/org/codehaus/jparsec/parameters/Node.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/parameters/Node.java
@@ -1,0 +1,14 @@
+package org.codehaus.jparsec.parameters;
+
+
+public class Node {
+	private SourceInfo info;
+
+	public SourceInfo getInfo() {
+		return info;
+	}
+
+	public void setInfo(SourceInfo info) {
+		this.info = info;
+	}
+}

--- a/jparsec/src/test/java/org/codehaus/jparsec/parameters/RuntimeParamsTest.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/parameters/RuntimeParamsTest.java
@@ -1,0 +1,108 @@
+package org.codehaus.jparsec.parameters;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.codehaus.jparsec.Parser;
+import org.codehaus.jparsec.Scanners;
+import org.codehaus.jparsec.Terminals;
+import org.codehaus.jparsec.Parser.Mode;
+import org.codehaus.jparsec.functors.Map;
+import org.codehaus.jparsec.misc.Mapper;
+import org.codehaus.jparsec.parameters.MapListener;
+import org.codehaus.jparsec.parameters.Parameters;
+import org.codehaus.jparsec.parameters.ParseLevelState;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+
+@RunWith(Parameterized.class)
+public class RuntimeParamsTest {
+  
+  public static Terminals KEYWORDS = Terminals.operators(";").words(Scanners.IDENTIFIER).keywords(Arrays.asList(new String[]{"def"})).build();
+  
+  public static Parser<Object> TOKENIZER = KEYWORDS.tokenizer().cast().or(Scanners.IDENTIFIER);
+
+  public static Parser<Identifier> IDENTIFIER = Terminals.Identifier.PARSER.map(new Map<String, Identifier>() {
+    @Override
+    public Identifier map(String from) {
+      return new Identifier(from);
+    }
+  });
+  
+  public static Parser<Declaration> DECL = KEYWORDS.token("def").next(IDENTIFIER).followedBy(KEYWORDS.token(";")).map(new Map<Identifier, Declaration>() {
+    @Override
+    public Declaration map(Identifier id) {
+      return new Declaration(id);
+    }});
+  
+  public static Parser<Declaration> DECL2 = new Mapper<Declaration>() {
+    @SuppressWarnings("unused")
+    public Declaration map(Identifier id) {
+      return new Declaration(id);
+    }
+  }.sequence(KEYWORDS.token("def").next(IDENTIFIER).followedBy(KEYWORDS.token(";")));
+
+  @org.junit.runners.Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[] {DECL}, new Object[] {DECL2});
+  }
+  
+  private Parser<Declaration> parser;
+  
+  public RuntimeParamsTest(Parser<Declaration> parser) {
+    this.parser = parser;
+  }
+  
+  @Test
+  public void testSourceInfo() {
+    
+    class TestParameters extends Parameters {
+      private String filename;
+
+      public String getFilename() {
+        return filename;
+      }
+
+      public void setFilename(String filename) {
+        this.filename = filename;
+      }
+      
+    }
+    
+    TestParameters params = new TestParameters();
+    params.setFilename("filename");
+    params.setMapListener(new MapListener() {
+      @Override
+      public void onMap(Object object, ParseLevelState state) {
+        if (object instanceof Node) {
+          TestParameters params = (TestParameters) state.getParams();
+          
+          ((Node) object).setInfo(new SourceInfo(params.getFilename(), state
+              .getFirstToken().index(), state.getLastToken().index()
+              + state.getLastToken().length()));
+        }
+      }
+    });
+    
+    Parser<List<Declaration>> parser = this.parser.many().from(TOKENIZER, Scanners.WHITESPACES.optional());
+    List<Declaration> decls = parser.parse("def abcd; def efgh;", params);
+    Declaration decl = decls.get(0);
+    assertEquals("filename", decl.getInfo().getFilename());
+    assertEquals(0, decl.getInfo().getStart());
+    assertEquals(9, decl.getInfo().getEnd());
+    assertEquals(4, decl.getId().getInfo().getStart());
+    assertEquals(8, decl.getId().getInfo().getEnd());
+
+    decl = decls.get(1);
+    assertEquals("filename", decl.getInfo().getFilename());
+    assertEquals(10, decl.getInfo().getStart());
+    assertEquals(19, decl.getInfo().getEnd());
+    assertEquals(14, decl.getId().getInfo().getStart());
+    assertEquals(18, decl.getId().getInfo().getEnd());
+  }
+}

--- a/jparsec/src/test/java/org/codehaus/jparsec/parameters/SourceInfo.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/parameters/SourceInfo.java
@@ -1,0 +1,26 @@
+package org.codehaus.jparsec.parameters;
+
+public class SourceInfo {
+	private int start;
+	private int end;
+  private String filename;
+	
+  public SourceInfo(String filename, int start, int end) {
+		super();
+		this.filename = filename;
+		this.start = start;
+		this.end = end;
+	}
+
+	public int getStart() {
+		return start;
+	}
+
+	public int getEnd() {
+		return end;
+	}
+
+  public String getFilename() {
+    return filename;
+  }
+}


### PR DESCRIPTION
Hello,

I implemented a way to add runtime listeners to a parse. The listener il called when Parse.map() is called. For instance, it permits the implementation of "Locatable", as we discussed some time ago, in a non-intrusive way. 
I call it Parameters because I see it as a value holder for some other features. I intend to use I soon for the implementation of some conditionnal parsing.
