### PR TITLE
Fixed maven build errors

### DIFF
--- a/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/bnf/parser/TerminalParser.java
+++ b/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/bnf/parser/TerminalParser.java
@@ -41,7 +41,7 @@ public final class TerminalParser {
   static final Indentation INDENTATION = new Indentation();
   
   static Parser<?> term(String name) {
-    return Mapper._(TERMS.token(name));
+    return Mapper.skip(TERMS.token(name));
   }
   
   static <T> T parse(Parser<T> parser, String source) {

--- a/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/java/parser/TerminalParser.java
+++ b/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/java/parser/TerminalParser.java
@@ -15,7 +15,7 @@
  *****************************************************************************/
 package org.codehaus.jparsec.examples.java.parser;
 
-import static org.codehaus.jparsec.misc.Mapper._;
+import static org.codehaus.jparsec.misc.Mapper.skip;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -105,11 +105,11 @@ public final class TerminalParser {
     if (name.equals("<<") || name.equals(">>>")) {
       return adjacent(name);
     }
-    return _(TERMS.token(name));
+    return skip(TERMS.token(name));
   }
   
   static Parser<?> oneOf(String... names) {
-    return _(TERMS.token(names));
+    return skip(TERMS.token(names));
   }
   
   static <T> T parse(Parser<T> parser, String source) {
@@ -121,6 +121,6 @@ public final class TerminalParser {
   }
   
   public static Parser<?> phrase(String phrase) {
-    return _(TERMS.phrase(phrase.split("\\s+")));
+    return skip(TERMS.phrase(phrase.split("\\s+")));
   }
 }

--- a/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/sql/parser/TerminalParser.java
+++ b/jparsec-examples/src/main/java/org/codehaus/jparsec/examples/sql/parser/TerminalParser.java
@@ -66,10 +66,10 @@ final class TerminalParser {
   }
   
   public static Parser<?> term(String term) {
-    return Mapper._(TERMS.token(term));
+    return Mapper.skip(TERMS.token(term));
   }
   
   public static Parser<?> phrase(String phrase) {
-    return Mapper._(TERMS.phrase(phrase.split("\\s")));
+    return Mapper.skip(TERMS.phrase(phrase.split("\\s")));
   }
 }

--- a/jparsec/src/main/java/org/codehaus/jparsec/OperatorTable.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/OperatorTable.java
@@ -28,12 +28,13 @@ import org.codehaus.jparsec.internal.util.Lists;
  * and precedences are declared in this table.
  * 
  * <p>Operators have precedences. The higher the precedence number, the higher the precedence. For
- * the same precedence, prefix > postfix > left-associative > non-associative > right-asscociative.
+ * the same precedence, prefix &gt; postfix &gt; left-associative &gt; non-associative &gt; right-associative.
  *
- * <p>For example: <pre class="code">   {@code
- *   Unary<Integer> negate = new Unary<Integer>() {... return -n; }};
- *   Binary<Integer> plus = new Binary<Integer>() {... return a + b; }};
- *   Binary<Integer> minus = new Binary<Integer() {... return a - b; }};
+ * <p>For example: 
+ * {@code
+ *   Unary<Integer> negate = new Unary<Integer>() {... return -n; };
+ *   Binary<Integer> plus = new Binary<Integer>() {... return a + b; };
+ *   Binary<Integer> minus = new Binary<Integer>() {... return a - b; };
  *   ...
  *   Terminals terms = Terminals.operators("+", "-", "*", "/");
  *   Parser<Integer> calculator = new OperatorTable()
@@ -46,7 +47,7 @@ import org.codehaus.jparsec.internal.util.Lists;
  *   Parser<Integer> parser = calculator.from(
  *       terms.tokenizer().or(Terminals.IntegerLiteral.TOKENIZER), Scanners.WHITESPACES.optional());
  *   return parser.parse(text);
- * }</pre>
+ * }
  * 
  * @author Ben Yu
  */

--- a/jparsec/src/main/java/org/codehaus/jparsec/error/ParserException.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/error/ParserException.java
@@ -34,7 +34,6 @@ public class ParserException extends RuntimeException {
    * Creates a {@link ParserException} object.
    * 
    * @param details the {@link ParseErrorDetails} that describes the error details.
-   * @param moduleName the module name.
    * @param location the error location.
    */
   public ParserException(ParseErrorDetails details,  Location location) {
@@ -81,10 +80,8 @@ public class ParserException extends RuntimeException {
   }
 
   /**
-   * Returns the parse tree until the parse error happened, when either
-   * {@link org.codehaus.jparsec.Parser#parseTree parseTree()} was invoked or
-   * {@link Parser.Mode#DEBUG DEBUG mode} was used in
-   * {@link org.codehaus.jparsec.Parser#parse(CharSequence, org.codehaus.jparsec.Parser.Mode) parse()}.
+   * Returns the parse tree until the parse error happened, when 
+   * {@link org.codehaus.jparsec.Parser#parseTree parseTree()} was invoked.
    * {@code null} if absent.
    *
    * @since 2.3

--- a/jparsec/src/main/java/org/codehaus/jparsec/misc/Curry.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/misc/Curry.java
@@ -13,6 +13,7 @@ import org.codehaus.jparsec.Parser;
 import org.codehaus.jparsec.functors.Binary;
 import org.codehaus.jparsec.functors.Unary;
 import org.codehaus.jparsec.internal.annotations.Private;
+import static org.codehaus.jparsec.internal.util.Checks.checkArgument;
 
 /**
  * Curries the only public constructor defined in the {@code T} class and invokes it with

--- a/jparsec/src/main/java/org/codehaus/jparsec/misc/Mapper.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/misc/Mapper.java
@@ -38,6 +38,9 @@ import org.codehaus.jparsec.functors.Binary;
 import org.codehaus.jparsec.functors.Map;
 import org.codehaus.jparsec.functors.Unary;
 import org.codehaus.jparsec.internal.util.Lists;
+import static org.codehaus.jparsec.internal.util.Checks.checkArgument;
+import static org.codehaus.jparsec.internal.util.Checks.checkNotNullState;
+import static org.codehaus.jparsec.internal.util.Checks.checkState;
 
 /**
  * Allows mapping arbitrary number of {@link Parser} results  to an object of {@code T} type-safely
@@ -49,11 +52,13 @@ import org.codehaus.jparsec.internal.util.Lists;
  * subclass (or the curried constructor in target class).
  * 
  * <p> For example: <pre>
- * Parser&lt;Foo> fooParser = new Mapper&lt;Foo>() {
+ * {@code
+ * Parser<Foo> fooParser = new Mapper<Foo>() {
  *   Foo map(String s, Integer n, Bar bar, Baz baz) {
  *     return new Foo(s, n, bar, baz);
  *   }
  * }.sequence(stringParser, integerParser, barParser, bazParser);
+ * }
  * </pre>
  * 
  * <p> Alternatively, instead of sequencing the operands and operators directly,
@@ -66,8 +71,10 @@ import org.codehaus.jparsec.internal.util.Lists;
  * It allows currying constructor defined in the target class so that no explicit mapping code
  * is needed. For the above example, it can be more concisely written as:
  * <pre>
- * Parser&lt;Foo> fooParser = Mapper.curry(Foo.class)
+ * {@code
+ * Parser<Foo> fooParser = Mapper.curry(Foo.class)
  *     .sequence(stringParser, integerParser, barParser, bazParser);
+ * }
  * </pre>
  * 
  * <p> NOTE: cglib is required on the classpath.
@@ -107,20 +114,24 @@ public abstract class Mapper<T> {
    * </pre>
    * The parser that parses this expression with binary operator can be written as:
    * <pre>
-   * Parser&lt;Expression> binary(Parser&lt;Expression> operand, Parser&lt;Operator> operator) {
-   *   return Sequencer.&lt;Expression>curry(BinaryExpression.class)
+   * {@code 
+   * Parser<Expression> binary(Parser<Expression> operand, Parser<Operator> operator) {
+   *   return Sequencer.<Expression>curry(BinaryExpression.class)
    *       .sequence(operand, operator, operand);
+   * }
    * }
    * </pre>
    * Which is equivalent to the more verbose but reflection-free version:
    * <pre>
-   * Parser&lt;Expression> binary(Parser&lt;Expression> expr, Parser&lt;Operator> op) {
+   * {@code 
+   * Parser<Expression> binary(Parser<Expression> expr, Parser<Operator> op) {
    *   return Parsers.sequence(expr, op, expr,
-   *       new Map3&lt;Expression, Operator, Expression, Expression>() {
+   *       new Map3<Expression, Operator, Expression, Expression>() {
    *         public Expression map(Expression left, Operator op, Expression right) {
    *           return new BinaryExpression(left, op, right);
    *         }
    *       });
+   * }
    * }
    * </pre>
    */
@@ -167,17 +178,22 @@ public abstract class Mapper<T> {
    * 
    * <p> For example:
    * <pre>
-   * Parser&lt;Unary&lt;Expression>> prefixOperator(Parser&lt;Operator> op) {
-   *   return new Mapper&lt;Expression>() {
+   * {@code 
+   * Parser<Unary&lt;Expression>> prefixOperator(Parser<Operator> op) {
+   *   return new Mapper<Expression>() {
    *     Expression map(Operator operator, Expression operand) {
    *       return new PrefixExpression(operator, operand);
    *     }
    *   }.prefix(op);
    * }
+   * }
    * </pre>
+   * <pre>
+   * {@code 
    * Or alternatively, by using the {@link #curry(Class, Object[])} method: <pre>
-   * Parser&lt;Unary&lt;Expression>> prefixOperator(Parser&lt;Operator> op) {
-   *   return Mapper.&lt;Expression>curry(PrefixExpression.class).prefix(op);
+   * Parser<Unary<Expression>> prefixOperator(Parser<Operator> op) {
+   *   return Mapper.<Expression>curry(PrefixExpression.class).prefix(op);
+   * }
    * }
    * </pre>
    * 
@@ -207,16 +223,20 @@ public abstract class Mapper<T> {
    * than one components. For example, the Java label statement (like {@code here:}) can be
    * modeled as a prefix operator applied to statements:
    * <pre>
+   * {@code 
    * Parser&lt;Unary&lt;Statement>> label = new Mapper&lt;Statement>() {
-   *   Statement map(String label, Statement statement) {
-   *     return new LabelStatement(label, statement);
-   *   }
-   * }.prefix(Terminals.STRING, _(terminal(":")));
+   *     Statement map(String label, Statement statement) {
+   *         return new LabelStatement(label, statement);
+   *     }
+   * }.prefix(Terminals.STRING, skip(terminal(":")));
+   * }
    * </pre>
    * Or alternatively, by using the {@link #curry(Class, Object[])} method:
    * <pre>
-   * Parser&lt;Unary&lt;Statement>> label = Mapper.&lt;Statement>curry(LabelStatement.class)
-   *     .prefix(Terminals.STRING, _(terminal(":")));
+   * {@code
+   * Parser<Unary<Statement>> label = Mapper<Statement>curry(LabelStatement.class)
+   *  .prefix(Terminals.STRING, skip(terminal(":")));
+   * }
    * </pre>
    * 
    * <p> Useful when the returned parser is used in {@link Parser#prefix(Parser)} or
@@ -245,17 +265,22 @@ public abstract class Mapper<T> {
    * 
    * <p> For example:
    * <pre>
-   * Parser&lt;Binary&lt;Expression>> postfixOperator(Parser&lt;Operator> op) {
-   *   return new Mapper&lt;Expression>() {
+   * {@code 
+   * Parser<Binary<Expression>> postfixOperator(Parser<Operator> op) {
+   *   return new Mapper<Expression>() {
    *     Expression map(Expression operand, Operator operator) {
    *       return new PostfixExpression(operand, operator);
    *     }
    *   }.postfix(op);
    * }
+   * }
    * </pre>
-   * Or alternatively, by using the {@link #curry(Class, Object[])} method: <pre>
-   * Parser&lt;Unary&lt;Expression>> postfixOperator(Parser&lt;Operator> op) {
-   *   return Mapper.&lt;Expression>curry(PostfixExpression.class).postfix(op);
+   * Or alternatively, by using the {@link #curry(Class, Object[])} method:
+   * <pre>
+   * {@code 
+   * Parser<Unary<Expression>> postfixOperator(Parser<Operator> op) {
+   *   return Mapper.<Expression>curry(PostfixExpression.class).postfix(op);
+   * }
    * }
    * </pre>
    * 
@@ -289,19 +314,23 @@ public abstract class Mapper<T> {
    * {@code array} expression to an array slice expression.
    * The parser can be written as:
    * <pre>
-   * Parser&lt;Unary&lt;Expression>> slice(Parser&lt;Expression bound) {
-   *   return new Mapper&lt;Expression>() {
-   *     Expression map(Expression array, Expression from, Expression to) {
-   *       return new ArraySliceExpression(array, from, to);
-   *     }
-   *   }.postfix(_(terminal("[")), bound, _(terminal(",")), bound, _(terminal("]")));
+   * {@code 
+   * Parser<Unary<Expression>> slice(Parser<Expression> bound) {
+   *   return new Mapper<Expression>() {
+   *  Expression map(Expression array, Expression from, Expression to) {
+   *    return new ArraySliceExpression(array, from, to);
+   *  }
+   * }.postfix(skip(terminal("[")), bound, skip(terminal(",")), bound, skip(terminal("]")));
+   * }
    * }
    * </pre>
    * Or alternatively, by using the {@link #curry(Class, Object[])} method:
    * <pre>
-   * Parser&lt;Unary&lt;Expression>> slice(Parser&lt;Expression bound) {
-   *   return Mapper.&lt;Expression>curry(ArraySliceExpression.class)
-   *       .postfix(_(terminal("[")), bound, _(terminal(",")), bound, _(terminal("]")));
+   * {@code 
+   * Parser<Unary<Expression>> slice(Parser<Expression bound) {
+   *   return Mapper.<Expression>curry(ArraySliceExpression.class)
+   *       .postfix(skip(terminal("[")), bound, skip(terminal(",")), bound, skip(terminal("]")));
+   * }
    * }
    * </pre>
    * 
@@ -333,17 +362,22 @@ public abstract class Mapper<T> {
    * 
    * <p> For example:
    * <pre>
-   * Parser&lt;Binary&lt;Expression>> infixOperator(Parser&lt;Operator> op) {
-   *   return new Mapper&lt;Expression>() {
+   * {@code 
+   * Parser<Binary<Expression>> infixOperator(Parser<Operator> op) {
+   *   return new Mapper<Expression>() {
    *     Expression map(Expression left, Operator operator, Expression right) {
    *       return new InfixExpression(left, operand, right);
    *     }
    *   }.infix(op);
    * }
+   * }
    * </pre>
-   * Or alternatively, by using the {@link #curry(Class, Object[])} method: <pre>
-   * Parser&lt;Binary&lt;Expression>> infixOperator(Parser&lt;Operator> op) {
-   *   return Mapper.&lt;Expression>curry(InfixExpression.class).infix(op);
+   * Or alternatively, by using the {@link #curry(Class, Object[])} method:
+   * <pre>
+   * {@code 
+   * Parser<Binary<Expression>> infixOperator(Parser<Operator> op) {
+   *   return Mapper.<Expression>curry(InfixExpression.class).infix(op);
+   * }
    * }
    * </pre>
    * 
@@ -376,19 +410,23 @@ public abstract class Mapper<T> {
    * {@code ? consequence :} part as a right associative infix operator that binds the condition and
    * the alternative expression together as a composite expression. The parser can be written as:
    * <pre>
-   * Parser&lt;Binary&lt;Expression>> conditional(Parser&lt;Expression> expr) {
-   *   return new Mapper&lt;Expression>() {
+   * {@code 
+   * Parser<Binary<Expression>> conditional(Parser<Expression> expr) {
+   *   return new Mapper<Expression>() {
    *     Expression map(Expression condition, Expression consequence, Expression alternative) {
    *       return new ConditionalExpression(condition, consequence, alternative);
    *     }
-   *   }.postfix(_(terminal("?")), expr, _(terminal(":")));
+   *   }.postfix(skip(terminal("?")), expr, skip(terminal(":")));
+   * }
    * }
    * </pre>
    * Or alternatively, by using the {@link #curry(Class, Object[])} method:
    * <pre>
-   * Parser&lt;Binary&lt;Expression>> conditional(Parser&lt;Expression> expr) {
-   *   return Mapper.&lt;Expression>.curry(ConditionalExpression.class)
-   *       .postfix(_(terminal("?")), expr, _(terminal(":")));
+   * {@code 
+   * Parser<Binary<Expression>> conditional(Parser<Expression> expr) {
+   *   return Mapper.<Expression>.curry(ConditionalExpression.class)
+   *     .postfix(skip(terminal("?")), expr, skip(terminal(":")));
+   * }
    * }
    * </pre>
    * 
@@ -421,15 +459,19 @@ public abstract class Mapper<T> {
    * maps the two expressions after "if" and "else" to the constructor of {@code IfElseExpression}
    * and skips the return values of the keyword "if" and "else".
    * <pre>
-   * Parser&lt;IfElseExpression> expression = curry(IfElseExpression.class).sequence(
-   *     _(word("if")), expr, _(word("else")), expr);
+   * {@code
+   * Parser<IfElseExpression> expression = curry(IfElseExpression.class).sequence(
+   *  skip(word("if")), expr, skip(word("else")), expr);
+   * }
    * </pre>
    */
-  public static final Parser<?> _(Parser<?> parser) {
+  public static final Parser<?> skip(Parser<?> parser) {
     return parser.map(SKIP);
   }
   
-  /** Returns the string representation of this object. */
+  /** 
+   * @return the string representation of this object. 
+   */
   @Override public String toString() {
     return source.toString();
   }

--- a/jparsec/src/main/java/org/codehaus/jparsec/pattern/Patterns.java
+++ b/jparsec/src/main/java/org/codehaus/jparsec/pattern/Patterns.java
@@ -77,7 +77,6 @@ public final class Patterns {
    * A {@link Pattern} object that matches a decimal number that has at least one digit before the decimal point. The
    * decimal point and the numbers to the right are optional.
    *
-   * <p/>
    * <p> {@code 0, 11., 2.3} are all good candidates. While {@code .1, .} are not.
    */
   public static final Pattern STRICT_DECIMAL = INTEGER.next(isChar('.').next(many(CharPredicates.IS_DIGIT)).optional());

--- a/jparsec/src/test/java/org/codehaus/jparsec/misc/CurryTest.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/misc/CurryTest.java
@@ -2,7 +2,6 @@ package org.codehaus.jparsec.misc;
 
 import static org.codehaus.jparsec.Parsers.constant;
 import static org.codehaus.jparsec.Scanners.string;
-import static org.codehaus.jparsec.misc.Mapper._;
 import static org.junit.Assert.*;
 
 import org.codehaus.jparsec.Parser;
@@ -12,6 +11,8 @@ import org.codehaus.jparsec.functors.Binary;
 import org.codehaus.jparsec.functors.Unary;
 import org.codehaus.jparsec.util.ObjectTester;
 import org.junit.Test;
+import static org.codehaus.jparsec.misc.Mapper.skip;
+import static org.codehaus.jparsec.Scanners.string;
 
 /**
  * Unit test for {@link Curry}.
@@ -166,7 +167,7 @@ public class CurryTest {
 
   @Test
   public void testPrefix_onlyOneUnskippedOperator() {
-    Expr result = Curry.<Expr>of(PrefixExpr.class).prefix(_(string("foo")), constant("x"))
+    Expr result = Curry.<Expr>of(PrefixExpr.class).prefix(skip(string("foo")), constant("x"))
         .parse("foo").map(FAKE_EXPR);
     PrefixExpr prefix = (PrefixExpr) result;
     assertEquals("x", prefix.op);
@@ -194,7 +195,7 @@ public class CurryTest {
 
   @Test
   public void testPostfix_onlyOneUnskippedOperator() {
-    Expr result = Curry.<Expr>of(PostfixExpr.class).postfix(_(string("foo")), constant("x"))
+    Expr result = Curry.<Expr>of(PostfixExpr.class).postfix(skip(string("foo")), constant("x"))
         .parse("foo").map(FAKE_EXPR);
     PostfixExpr postfix = (PostfixExpr) result;
     assertEquals("x", postfix.op);
@@ -227,7 +228,7 @@ public class CurryTest {
   public void testInfix_onlyOneUnskippedOperator() {
     Expr left = FAKE_EXPR;
     Expr right = new Expr() {};
-    Expr result = Curry.<Expr>of(InfixExpr.class).infix(_(string("foo")), constant("x"))
+    Expr result = Curry.<Expr>of(InfixExpr.class).infix(skip(string("foo")), constant("x"))
         .parse("foo").map(left, right);
     InfixExpr infix = (InfixExpr) result;
     assertEquals("x", infix.op);

--- a/jparsec/src/test/java/org/codehaus/jparsec/misc/MapperTest.java
+++ b/jparsec/src/test/java/org/codehaus/jparsec/misc/MapperTest.java
@@ -1,7 +1,6 @@
 package org.codehaus.jparsec.misc;
 
 import static org.codehaus.jparsec.Parsers.constant;
-import static org.codehaus.jparsec.misc.Mapper._;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
@@ -13,6 +12,7 @@ import org.codehaus.jparsec.Parsers;
 import org.codehaus.jparsec.functors.Binary;
 import org.codehaus.jparsec.functors.Unary;
 import org.junit.Test;
+import static org.codehaus.jparsec.misc.Mapper.skip;
 
 /**
  * Unit test for {@link Mapper}.
@@ -281,69 +281,61 @@ public class MapperTest {
   @Test
   public void testParametersSkippedForSequence() {
     assertEquals("foo12truec",
-        Mapper.curry(Thing.class, "foo", 1, 2L).sequence(
-            _(constant("bar")), constant(true), constant('c')).parse("").toString());
+        Mapper.curry(Thing.class, "foo", 1, 2L).sequence(skip(constant("bar")), constant(true), constant('c')).parse("").toString());
     assertEquals("foo12truec",
-        Mapper.curry(Thing.class, "foo", 1, 2L).sequence(
-            _(constant(false)), constant(true),
-            _(constant("bar")), _(constant(false)), constant('c'),
-            _(constant('d')), _(constant('e'))).parse("").toString());
+        Mapper.curry(Thing.class, "foo", 1, 2L).sequence(skip(constant(false)), constant(true),
+            skip(constant("bar")), skip(constant(false)), constant('c'),
+            skip(constant('d')), skip(constant('e'))).parse("").toString());
     assertFoo("foo",
-        fooMapper().sequence(_(constant("bar")), constant("foo"), constant(1)).parse(""));
+        fooMapper().sequence(skip(constant("bar")), constant("foo"), constant(1)).parse(""));
   }
 
   @Test
   public void testParametersSkippedForPrefix() {
     assertEquals("foo12truec",
-        Mapper.<Object>curry(Thing.class, "foo", 2L).prefix(
-            constant(1), _(constant("bar")), constant(true)).parse("").map('c').toString());
+        Mapper.<Object>curry(Thing.class, "foo", 2L).prefix(constant(1), skip(constant("bar")), constant(true)).parse("").map('c').toString());
     assertEquals("thing12truec",
-        thingMapper().prefix(
-            constant(1), _(constant("bar")), constant(true)).parse("").map('c').toString());
+        thingMapper().prefix(constant(1), skip(constant("bar")), constant(true)).parse("").map('c').toString());
   }
 
   @Test
   public void testParametersSkippedForPostfix() {
     assertEquals("foo12truec",
-        Mapper.<Object>curry(Thing.class, "foo", 2L).postfix(
-            _(constant("bar")), constant(true), constant('c')).parse("").map(1).toString());
+        Mapper.<Object>curry(Thing.class, "foo", 2L).postfix(skip(constant("bar")), constant(true), constant('c')).parse("").map(1).toString());
     assertEquals("thing12truec",
-        thingMapper().postfix(
-            _(constant("bar")), constant(true), constant('c')).parse("").map(1).toString());
+        thingMapper().postfix(skip(constant("bar")), constant(true), constant('c')).parse("").map(1).toString());
   }
 
   @Test
   public void testParametersSkippedForInfix() {
     assertEquals("foo12truec",
-        Mapper.<Object>curry(Thing.class, "foo", 2L).infix(
-            constant(true), _(constant("bar"))).parse("").map(1, 'c').toString());
+        Mapper.<Object>curry(Thing.class, "foo", 2L).infix(constant(true), skip(constant("bar"))).parse("").map(1, 'c').toString());
     assertEquals("thing12truec",
-        thingMapper().infix(
-            constant(true), _(constant("bar"))).parse("").map(1, 'c').toString());
+        thingMapper().infix(constant(true), skip(constant("bar"))).parse("").map(1, 'c').toString());
   }
 
   @Test
   public void testInvalidSkipForPrefix() {
     try {
-      Mapper.<Object>curry(Foo.class).prefix(_(constant("bar")));
+      Mapper.<Object>curry(Foo.class).prefix(skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      Mapper.<Object>curry(Foo.class).prefix(_(constant(1)), _(constant("bar")));
+      Mapper.<Object>curry(Foo.class).prefix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());
     }
     try {
-      fooMapper().prefix(_(constant(1)));
+      fooMapper().prefix(skip(constant(1)));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      fooMapper().prefix(_(constant(1)), _(constant("bar")));
+      fooMapper().prefix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());
@@ -353,25 +345,25 @@ public class MapperTest {
   @Test
   public void testInvalidSkipForPostfix() {
     try {
-      Mapper.<Object>curry(Foo.class).postfix(_(constant("bar")));
+      Mapper.<Object>curry(Foo.class).postfix(skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      Mapper.<Object>curry(Foo.class).postfix(_(constant(1)), _(constant("bar")));
+      Mapper.<Object>curry(Foo.class).postfix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());
     }
     try {
-      fooMapper().postfix(_(constant(1)));
+      fooMapper().postfix(skip(constant(1)));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      fooMapper().postfix(_(constant(1)), _(constant("bar")));
+      fooMapper().postfix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());
@@ -381,25 +373,25 @@ public class MapperTest {
   @Test
   public void testInvalidSkipForInfix() {
     try {
-      Mapper.<Object>curry(Foo.class).infix(_(constant("bar")));
+      Mapper.<Object>curry(Foo.class).infix(skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      Mapper.<Object>curry(Foo.class).infix(_(constant(1)), _(constant("bar")));
+      Mapper.<Object>curry(Foo.class).infix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());
     }
     try {
-      fooMapper().infix(_(constant(1)));
+      fooMapper().infix(skip(constant(1)));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip the only parser parameter.", e.getMessage());
     }
     try {
-      fooMapper().infix(_(constant(1)), _(constant("bar")));
+      fooMapper().infix(skip(constant(1)), skip(constant("bar")));
       fail();
     } catch (IllegalArgumentException e) {
       assertEquals("Cannot skip all parser parameters.", e.getMessage());


### PR DESCRIPTION
Hello people,

I've just pulled from master, but the maven build failed. I've done the following changes to make it work again:

* Updated JavaDoc to use `{@code }` rather than html entities.
* refactored `Mapper._` to `Mapper.skip`, as '_' will not be a legal method name after Java 8

Cheers,
Michael