### PR TITLE
Add `Automatic-Module-Name` in build to enable module support

### DIFF
--- a/jparsec/pom.xml
+++ b/jparsec/pom.xml
@@ -40,4 +40,20 @@
     </dependency>
   </dependencies>
 
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jparsec</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
- Add `Automatic-Module-Name` in jar Manifest through maven jar plugin to allow usage of the library in Jigsaw modules aware projects.

----

The change is necessary to allow projects that are using Java 9 modules to include safely JParsec in their build and publish their artifact. Given Java 8 is reaching [end of support for commercial uses in January 2019](https://www.oracle.com/technetwork/java/java-se-support-roadmap.html), in order to create new projects that will use JParsec which can be published in repositories, it is [necessary for all included dependencies to have explicit names](https://stackoverflow.com/questions/46501047/what-does-required-filename-based-automodules-detected-warning-mean).

The addition of the `Automatic-Module-Name` configuration in the creation of the jars will make every package in JParsec `exported` and hence accessible and will set the module name to be used to `org.jparsec`.

It is possible to introduce an explicit `module-info` to enforce stronger encapsulation, but this will make the library compatible only with Java9+. The proposed addition will still allow the inclusion of the library to Java8 projects (it is the [same change](https://github.com/google/guava/pull/2846) applied by Guava)