### PR TITLE
Make otherwise() work when following other parsers

### DIFF
--- a/jparsec/src/main/java/org/jparsec/Parser.java
+++ b/jparsec/src/main/java/org/jparsec/Parser.java
@@ -326,9 +326,8 @@ public abstract class Parser<T> {
         final Object result = ctxt.result;
         final int at = ctxt.at;
         final int step = ctxt.step;
-        final int errorIndex = ctxt.errorIndex();
         if (Parser.this.apply(ctxt)) return true;
-        if (ctxt.errorIndex() != errorIndex) return false;
+        if (ctxt.errorIndex() > at) return false;
         ctxt.set(step, at, result);
         return fallback.apply(ctxt);
       }

--- a/jparsec/src/test/java/org/jparsec/ParserTest.java
+++ b/jparsec/src/test/java/org/jparsec/ParserTest.java
@@ -292,6 +292,7 @@ public class ParserTest extends BaseMockTest {
   public void testOtherwise() {
     assertEquals((Object) 123, INTEGER.otherwise(constant(456)).parse("123", mode));
     assertEquals((Object) 'b', isChar('a').otherwise(constant('b')).parse("", mode));
+    assertEquals((Object) 'c', isChar('a').next(isChar('b').otherwise(constant('c'))).parse("a", mode));
     assertFailure(mode, areChars("ab").otherwise(isChar('a')), "a", 1, 2);
     assertFailure(mode, areChars("ab").or(isChar('x')).otherwise(isChar('a')), "a", 1, 2);
     assertFailure(mode, areChars("ab").otherwise(isChar('a')), "x", 1, 1);


### PR DESCRIPTION
Compare with the current `at` to decide whether input was consumed.

Since the starting errorIndex is typically 0, otherwise() sometimes only worked when at = 0.

Despite this change it can still be unwieldy with token level parsers because delimiters may offset the error index even if no tokens were consumed.