### PR TITLE
Improve build performance by turning off report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <modules>
@@ -248,6 +249,13 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+        </configuration>
+      </plugin>
+	    
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+	  <disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.