### PR TITLE
Java parser failed on assign binaryop expression to a variable.

### DIFF
--- a/jparsec-examples/src/test/java/org/jparsec/examples/java/parser/StatementParserTest.java
+++ b/jparsec-examples/src/test/java/org/jparsec/examples/java/parser/StatementParserTest.java
@@ -151,6 +151,7 @@ public class StatementParserTest {
   public void testVarStatement() {
     Parser<Statement> parser = StatementParser.varStatement(ExpressionParser.IDENTIFIER);
     TerminalParserTest.assertResult(parser, "int i;", VarStatement.class, "int i;");
+    TerminalParserTest.assertResult(parser, "int i=1+1;", VarStatement.class, "int i=1+1;");
     TerminalParserTest.assertResult(parser, "int i=n;", VarStatement.class, "int i = n;");
     TerminalParserTest.assertResult(parser, "final int i=n;", VarStatement.class, "final int i = n;");
     TerminalParserTest.assertResult(parser, "final int[] a1={}, a2, a3={m, n};",


### PR DESCRIPTION
Parse statement with code `int i=1+1;` fails with message:
```
org.jparsec.error.ParserException: line 1, column 7:
{ or IDENTIFIER expected, 1 encountered.
```